### PR TITLE
Stop checking encoding names

### DIFF
--- a/spec/coder_spec.rb
+++ b/spec/coder_spec.rb
@@ -34,7 +34,7 @@ describe Coder do
       it 'does not modify the encoding of the passed in string' do
         str = ''.encode('binary')
         Coder.force_encoding str
-        str.encoding.name.should be == 'ASCII-8BIT'
+        str.encoding.should be == Encoding::BINARY
       end
     end
   end


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576